### PR TITLE
feat(di): add telegram polling component

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/nomenarkt/vitaltrack/backend/internal/background"
 	"github.com/nomenarkt/vitaltrack/backend/internal/di"
-	"github.com/nomenarkt/vitaltrack/backend/internal/domain"
 	"github.com/nomenarkt/vitaltrack/backend/internal/server"
 )
 
@@ -39,22 +38,7 @@ func main() {
 
 	// 🧭 Start Telegram bot polling for `/stock` commands if enabled
 	if os.Getenv("ENABLE_TELEGRAM_POLLING") == "true" {
-		go deps.Telegram.PollForCommands(
-			func() ([]domain.Medicine, []domain.StockEntry, error) {
-				meds, err := deps.Airtable.FetchMedicines()
-				if err != nil {
-					return nil, nil, err
-				}
-				entries, err := deps.Airtable.FetchStockEntries()
-				if err != nil {
-					return nil, nil, err
-				}
-				return meds, entries, nil
-			},
-			func(y, m int) (domain.MonthlyFinancialReport, error) {
-				return deps.FinancialSvc.GenerateFinancialReport(y, m)
-			},
-		)
+		di.StartTelegramPolling(deps)
 	}
 
 	// 🚀 Run server

--- a/backend/internal/di/telegram_polling.go
+++ b/backend/internal/di/telegram_polling.go
@@ -1,0 +1,25 @@
+package di
+
+import (
+	"github.com/nomenarkt/vitaltrack/backend/internal/domain"
+)
+
+// StartTelegramPolling launches polling for Telegram bot commands.
+func StartTelegramPolling(deps Dependencies) {
+	go deps.Telegram.PollForCommands(
+		func() ([]domain.Medicine, []domain.StockEntry, error) {
+			meds, err := deps.Airtable.FetchMedicines()
+			if err != nil {
+				return nil, nil, err
+			}
+			entries, err := deps.Airtable.FetchStockEntries()
+			if err != nil {
+				return nil, nil, err
+			}
+			return meds, entries, nil
+		},
+		func(y, m int) (domain.MonthlyFinancialReport, error) {
+			return deps.FinancialSvc.GenerateFinancialReport(y, m)
+		},
+	)
+}

--- a/backend/internal/di/telegram_polling_test.go
+++ b/backend/internal/di/telegram_polling_test.go
@@ -1,0 +1,72 @@
+package di_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/vitaltrack/backend/internal/di"
+	"github.com/nomenarkt/vitaltrack/backend/internal/domain"
+	"github.com/nomenarkt/vitaltrack/backend/internal/usecase"
+)
+
+type mockAirtable struct {
+	medsCalled    bool
+	entriesCalled bool
+}
+
+func (m *mockAirtable) FetchMedicines() ([]domain.Medicine, error) {
+	m.medsCalled = true
+	return []domain.Medicine{{ID: "1"}}, nil
+}
+func (m *mockAirtable) FetchStockEntries() ([]domain.StockEntry, error) {
+	m.entriesCalled = true
+	return []domain.StockEntry{}, nil
+}
+func (m *mockAirtable) CreateStockEntry(domain.StockEntry) error              { return nil }
+func (m *mockAirtable) UpdateForecastDate(string, time.Time, time.Time) error { return nil }
+func (m *mockAirtable) FetchFinancialEntries(int, time.Month) ([]domain.FinancialEntry, error) {
+	return nil, nil
+}
+func (m *mockAirtable) UpdateMedicineLastAlertedDate(string, time.Time) error { return nil }
+
+type mockFinanceRepo struct{ called bool }
+
+func (m *mockFinanceRepo) FetchFinancialEntries(int, time.Month) ([]domain.FinancialEntry, error) {
+	m.called = true
+	return nil, nil
+}
+
+type mockTelegram struct{ done chan struct{} }
+
+func (m *mockTelegram) SendTelegramMessage(string) error { return nil }
+func (m *mockTelegram) PollForCommands(fetch func() ([]domain.Medicine, []domain.StockEntry, error), report func(int, int) (domain.MonthlyFinancialReport, error)) {
+	fetch()
+	report(2024, 6)
+	close(m.done)
+}
+
+func TestStartTelegramPolling(t *testing.T) {
+	at := &mockAirtable{}
+	repo := &mockFinanceRepo{}
+	tg := &mockTelegram{done: make(chan struct{})}
+	deps := di.Dependencies{
+		Airtable:     at,
+		Telegram:     tg,
+		FinancialSvc: usecase.FinancialReportService{Repo: repo},
+	}
+
+	di.StartTelegramPolling(deps)
+
+	select {
+	case <-tg.done:
+	case <-time.After(time.Second):
+		t.Fatal("polling not invoked")
+	}
+
+	if !at.medsCalled || !at.entriesCalled {
+		t.Errorf("fetch functions not used")
+	}
+	if !repo.called {
+		t.Errorf("financial report not called")
+	}
+}


### PR DESCRIPTION
## Summary
- add `StartTelegramPolling` helper to DI layer
- wire polling through `cmd/server`
- test new helper

## Testing
- `staticcheck ./...` *(fails: requires newer Go version)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ac2e333f483299a86fc5c4dee950c