### PR TITLE
feat(server): centralize stock calculations

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -20,7 +20,7 @@ func main() {
 	deps := di.Init()
 
 	// ✅ Setup all HTTP routes with DI
-	server.SetupRoutes(app, deps.StockChecker, deps.ForecastSvc, deps.Airtable, deps.Telegram)
+	server.SetupRoutes(app, deps.StockChecker, deps.ForecastSvc, deps.MedicineSvc, deps.Airtable, deps.Telegram)
 
 	// 🔄 Start background stock check if enabled
 	tickerInterval := 24 * time.Hour

--- a/backend/internal/di/di.go
+++ b/backend/internal/di/di.go
@@ -13,6 +13,7 @@ type Dependencies struct {
 	StockChecker *usecase.StockChecker
 	ForecastSvc  usecase.OutOfStockService
 	FinancialSvc usecase.FinancialReportService
+	MedicineSvc  usecase.MedicineService
 }
 
 func Init() Dependencies {
@@ -30,5 +31,6 @@ func Init() Dependencies {
 			Airtable: at,
 		},
 		FinancialSvc: usecase.FinancialReportService{Repo: at},
+		MedicineSvc:  usecase.MedicineService{Repo: at},
 	}
 }

--- a/backend/internal/usecase/medicine.go
+++ b/backend/internal/usecase/medicine.go
@@ -1,0 +1,62 @@
+package usecase
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/nomenarkt/vitaltrack/backend/internal/domain"
+	"github.com/nomenarkt/vitaltrack/backend/internal/domain/ports"
+	"github.com/nomenarkt/vitaltrack/backend/internal/logic/stockcalc"
+)
+
+// MedicineService provides stock related operations.
+type MedicineService struct {
+	Repo ports.StockDataPort
+}
+
+var ErrMedicineNotFound = errors.New("medicine not found")
+
+// StockInfo summarizes current stock information for a medicine.
+type StockInfo struct {
+	InitialStock   float64
+	ConsumedStock  float64
+	CurrentStock   float64
+	OutOfStockDate time.Time
+}
+
+// GetStockInfo computes current stock and forecast for the given medicine.
+func (s MedicineService) GetStockInfo(id string, now time.Time) (StockInfo, error) {
+	meds, err := s.Repo.FetchMedicines()
+	if err != nil {
+		return StockInfo{}, fmt.Errorf("fetch medicines failed: %w", err)
+	}
+	entries, err := s.Repo.FetchStockEntries()
+	if err != nil {
+		return StockInfo{}, fmt.Errorf("fetch stock entries failed: %w", err)
+	}
+
+	var med *domain.Medicine
+	for _, m := range meds {
+		if m.ID == id {
+			tmp := m
+			med = &tmp
+			break
+		}
+	}
+	if med == nil {
+		return StockInfo{}, ErrMedicineNotFound
+	}
+
+	stock := stockcalc.CurrentStockAt(*med, entries, now)
+	forecast := stockcalc.OutOfStockDateAt(*med, stock, now)
+
+	info := StockInfo{
+		InitialStock:   med.InitialStock,
+		ConsumedStock:  math.Max(med.InitialStock-stock, 0),
+		CurrentStock:   stock,
+		OutOfStockDate: forecast,
+	}
+	return info, nil
+}

--- a/backend/internal/usecase/medicine_test.go
+++ b/backend/internal/usecase/medicine_test.go
@@ -1,0 +1,85 @@
+package usecase_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/vitaltrack/backend/internal/domain"
+	"github.com/nomenarkt/vitaltrack/backend/internal/usecase"
+)
+
+type mockRepo struct {
+	meds    []domain.Medicine
+	entries []domain.StockEntry
+}
+
+func (m mockRepo) FetchMedicines() ([]domain.Medicine, error) {
+	return m.meds, nil
+}
+func (m mockRepo) FetchStockEntries() ([]domain.StockEntry, error) {
+	return m.entries, nil
+}
+func (m mockRepo) FetchFinancialEntries(int, time.Month) ([]domain.FinancialEntry, error) {
+	return nil, nil
+}
+func (m mockRepo) CreateStockEntry(domain.StockEntry) error              { return nil }
+func (m mockRepo) UpdateForecastDate(string, time.Time, time.Time) error { return nil }
+
+func TestGetStockInfo(t *testing.T) {
+	now := time.Date(2025, 6, 4, 0, 0, 0, 0, time.UTC)
+	med := domain.Medicine{
+		ID: "m1", Name: "Med1", StartDate: domain.NewFlexibleDate(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)),
+		InitialStock: 10, DailyDose: 1, UnitPerBox: 10,
+	}
+	tests := []struct {
+		name      string
+		repo      mockRepo
+		wantStock float64
+		wantDate  time.Time
+		wantErr   bool
+	}{
+		{
+			name:      "found",
+			repo:      mockRepo{meds: []domain.Medicine{med}},
+			wantStock: 7,
+			wantDate:  time.Date(2025, 6, 11, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "withEntries",
+			repo:      mockRepo{meds: []domain.Medicine{med}, entries: []domain.StockEntry{{MedicineID: "m1", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)}}},
+			wantStock: 17,
+			wantDate:  time.Date(2025, 6, 21, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "not_found",
+			repo:    mockRepo{meds: []domain.Medicine{}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := usecase.MedicineService{Repo: tt.repo}
+			info, err := svc.GetStockInfo("m1", now)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if !errors.Is(err, usecase.ErrMedicineNotFound) {
+					t.Fatalf("wrong error: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if info.CurrentStock != tt.wantStock {
+				t.Errorf("stock=%.2f want %.2f", info.CurrentStock, tt.wantStock)
+			}
+			if !info.OutOfStockDate.Equal(tt.wantDate) {
+				t.Errorf("date=%s want %s", info.OutOfStockDate.Format("2006-01-02"), tt.wantDate.Format("2006-01-02"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `MedicineService` usecase to encapsulate stock computations
- update DI and server routes to use the service
- compute stock JSON via the usecase
- add tests for `MedicineService`

## Testing
- `go test ./...`
- `staticcheck ./...` *(fails: requires newer Go version)*

------
https://chatgpt.com/codex/tasks/task_e_684ac5a85bb88329b7f2c6955fa6d39d