### PR TITLE
fix(background): use structured logging

### DIFF
--- a/backend/internal/background/ticker.go
+++ b/backend/internal/background/ticker.go
@@ -26,16 +26,16 @@ func StartStockAlertTicker(deps di.Dependencies, interval time.Duration, nowFn f
 
 			meds, err := deps.Airtable.FetchMedicines()
 			if err != nil {
-				log.Println("❌ fetch medicines failed:", err)
-				log.Println("🔁 Alert ticker completed")
+				log.Printf("❌ fetch medicines failed: %v", err)
+				log.Printf("🔁 Alert ticker completed")
 				time.Sleep(interval)
 				continue
 			}
 
 			entries, err := deps.Airtable.FetchStockEntries()
 			if err != nil {
-				log.Println("❌ fetch stock entries failed:", err)
-				log.Println("🔁 Alert ticker completed")
+				log.Printf("❌ fetch stock entries failed: %v", err)
+				log.Printf("🔁 Alert ticker completed")
 				time.Sleep(interval)
 				continue
 			}
@@ -60,14 +60,14 @@ func StartStockAlertTicker(deps di.Dependencies, interval time.Duration, nowFn f
 						stock,
 					)
 					if err := deps.Telegram.SendTelegramMessage(msg); err != nil {
-						log.Println("❌ Telegram send failed:", err)
+						log.Printf("❌ Telegram send failed: %v", err)
 					} else {
 						log.Printf("📣 Alert sent for %s", m.Name)
 					}
 				}
 			}
 
-			log.Println("🔁 Alert ticker completed")
+			log.Printf("🔁 Alert ticker completed")
 
 			select {
 			case <-stopCh:

--- a/backend/internal/usecase/alert.go
+++ b/backend/internal/usecase/alert.go
@@ -22,7 +22,7 @@ type StockChecker struct {
 // CheckAndAlertLowStock scans medicines and alerts if 10 days from out-of-stock.
 func (s *StockChecker) CheckAndAlertLowStock() error {
 	now := time.Now().UTC()
-	log.Println("📡 Starting CheckAndAlertLowStock...")
+	log.Printf("📡 Starting CheckAndAlertLowStock...")
 
 	meds, err := s.Airtable.FetchMedicines()
 	if err != nil {
@@ -76,7 +76,7 @@ func (s *StockChecker) CheckAndAlertLowStock() error {
 			if err := s.Telegram.SendTelegramMessage(alert); err != nil {
 				log.Printf("❌ Telegram send failed: %v", err)
 			} else {
-				log.Println("✅ Telegram message sent")
+				log.Printf("✅ Telegram message sent")
 			}
 
 			log.Printf("🧪 Calling UpdateMedicineLastAlertedDate for recordID=%s", m.ID)


### PR DESCRIPTION
## Summary
- replace `log.Println` usages in background ticker with `log.Printf`
- update usecase alert logging to use `log.Printf`

## Testing
- `go test ./...`
- `staticcheck ./...` *(fails: unsupported version)*

------
https://chatgpt.com/codex/tasks/task_e_684acaf033e48329ac4ecc06ff79ea32