### PR TITLE
fix(ci): ensure coverage uploaded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,12 @@ jobs:
       - name: ✅ Run unit tests
         run: go test -v ./...
 
-      - name: 🧪 Generate test coverage
-        run: go test -coverprofile=coverage.out ./...
+      - name: 🧪 Run Go Coverage
+        run: |
+          # Ensure coverage.out exists at root. If changed, sync Codecov path and test.
+          go test -coverprofile=../coverage.out ./...
+          ls -lah ..
+          test -f ../coverage.out
 
       - name: 📊 Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Summary
- run go test coverage from backend but move file to project root
- upload `./coverage.out` to Codecov

## Testing
- `act` *(fails: "Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.")*

------
https://chatgpt.com/codex/tasks/task_e_684ace0f870c832999d7484911e5478a