### PR TITLE
Fix Codecov coverage path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,17 @@ jobs:
 
       - name: 🧪 Run Go Coverage
         run: |
-          # Ensure coverage.out exists at root. If changed, sync Codecov path and test.
-          go test -coverprofile=../coverage.out ./...
-          ls -lah ..
-          test -f ../coverage.out
+          # Ensure coverage.out exists in the working directory. If changed, sync Codecov path and test.
+          go test -coverprofile=coverage.out ./...
+          ls -lah .
+          test -f coverage.out
 
       - name: 📊 Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage.out
           flags: backend
+          working-directory: backend
           fail_ci_if_error: true
 
       - name: 🧱 Build binary


### PR DESCRIPTION
## Summary
- ensure Go coverage profile is written within `backend/`
- verify coverage file in working directory and upload from there

## Testing
- `python - <<'PY'
import yaml
with open('.github/workflows/ci.yml') as f:
    yaml.safe_load(f)
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684ad097a45c8329a8d41c7c5a31b4f8