### PR TITLE
feat: introduce context-aware logger

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 	"time"
@@ -33,12 +34,12 @@ func main() {
 		}
 	}
 	if os.Getenv("ENABLE_ALERT_TICKER") == "true" {
-		background.StartStockAlertTicker(deps, tickerInterval, time.Now)
+		background.StartStockAlertTicker(context.Background(), deps, tickerInterval, time.Now)
 	}
 
 	// 🧭 Start Telegram bot polling for `/stock` commands if enabled
 	if os.Getenv("ENABLE_TELEGRAM_POLLING") == "true" {
-		di.StartTelegramPolling(deps)
+		di.StartTelegramPolling(context.Background(), deps)
 	}
 
 	// 🚀 Run server

--- a/backend/internal/di/app.go
+++ b/backend/internal/di/app.go
@@ -1,6 +1,7 @@
 package di
 
 import (
+	"context"
 	"os"
 	"time"
 )
@@ -8,15 +9,15 @@ import (
 var (
 	// StartTickerFunc points to the ticker starter implementation.
 	// Tests or callers should assign it to background.StartStockAlertTicker.
-	StartTickerFunc func(Dependencies, time.Duration, func() time.Time) func()
+	StartTickerFunc func(context.Context, Dependencies, time.Duration, func() time.Time) func()
 
 	// PollingFunc points to the Telegram polling starter implementation.
 	// Tests or callers should assign it to StartTelegramPolling.
-	PollingFunc func(Dependencies)
+	PollingFunc func(context.Context, Dependencies)
 )
 
 // StartFromEnv starts optional background processes based on environment flags.
-func StartFromEnv(deps Dependencies) {
+func StartFromEnv(ctx context.Context, deps Dependencies) {
 	tickerInterval := 24 * time.Hour
 	if val := os.Getenv("ALERT_TICKER_INTERVAL"); val != "" {
 		if d, err := time.ParseDuration(val); err == nil {
@@ -24,9 +25,9 @@ func StartFromEnv(deps Dependencies) {
 		}
 	}
 	if os.Getenv("ENABLE_ALERT_TICKER") == "true" && StartTickerFunc != nil {
-		StartTickerFunc(deps, tickerInterval, time.Now)
+		StartTickerFunc(ctx, deps, tickerInterval, time.Now)
 	}
 	if os.Getenv("ENABLE_TELEGRAM_POLLING") == "true" && PollingFunc != nil {
-		PollingFunc(deps)
+		PollingFunc(ctx, deps)
 	}
 }

--- a/backend/internal/di/di.go
+++ b/backend/internal/di/di.go
@@ -4,12 +4,14 @@ import (
 	"github.com/nomenarkt/vitaltrack/backend/internal/domain/ports"
 	"github.com/nomenarkt/vitaltrack/backend/internal/infra/airtable"
 	"github.com/nomenarkt/vitaltrack/backend/internal/infra/telegram"
+	"github.com/nomenarkt/vitaltrack/backend/internal/logger"
 	"github.com/nomenarkt/vitaltrack/backend/internal/usecase"
 )
 
 type Dependencies struct {
 	Airtable     ports.StockDataPort // satisfies AirtableService + StockDataPort
 	Telegram     ports.TelegramService
+	Logger       logger.Logger
 	StockChecker *usecase.StockChecker
 	ForecastSvc  usecase.OutOfStockService
 	FinancialSvc usecase.FinancialReportService
@@ -19,10 +21,12 @@ type Dependencies struct {
 func Init() Dependencies {
 	at := airtable.NewClient()
 	tg := telegram.NewClient()
+	lg := logger.NewStdLogger()
 
 	return Dependencies{
 		Airtable: at,
 		Telegram: tg,
+		Logger:   lg,
 		StockChecker: &usecase.StockChecker{
 			Airtable: at,
 			Telegram: tg,

--- a/backend/internal/di/telegram_polling.go
+++ b/backend/internal/di/telegram_polling.go
@@ -1,11 +1,14 @@
 package di
 
 import (
+	"context"
+
 	"github.com/nomenarkt/vitaltrack/backend/internal/domain"
 )
 
 // StartTelegramPolling launches polling for Telegram bot commands.
-func StartTelegramPolling(deps Dependencies) {
+func StartTelegramPolling(ctx context.Context, deps Dependencies) {
+	deps.Logger.Info(ctx, "telegram polling started")
 	go deps.Telegram.PollForCommands(
 		func() ([]domain.Medicine, []domain.StockEntry, error) {
 			meds, err := deps.Airtable.FetchMedicines()

--- a/backend/internal/di/telegram_polling_test.go
+++ b/backend/internal/di/telegram_polling_test.go
@@ -1,11 +1,13 @@
 package di_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/nomenarkt/vitaltrack/backend/internal/di"
 	"github.com/nomenarkt/vitaltrack/backend/internal/domain"
+	"github.com/nomenarkt/vitaltrack/backend/internal/logger"
 	"github.com/nomenarkt/vitaltrack/backend/internal/usecase"
 )
 
@@ -53,9 +55,10 @@ func TestStartTelegramPolling(t *testing.T) {
 		Airtable:     at,
 		Telegram:     tg,
 		FinancialSvc: usecase.FinancialReportService{Repo: repo},
+		Logger:       logger.NewStdLogger(),
 	}
 
-	di.StartTelegramPolling(deps)
+	di.StartTelegramPolling(context.Background(), deps)
 
 	select {
 	case <-tg.done:

--- a/backend/internal/logger/logger.go
+++ b/backend/internal/logger/logger.go
@@ -1,0 +1,44 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+)
+
+// Logger defines structured logging methods.
+type Logger interface {
+	Info(ctx context.Context, msg string, kv ...any)
+	Error(ctx context.Context, msg string, kv ...any)
+}
+
+// StdLogger logs to the standard library logger.
+type StdLogger struct{}
+
+// NewStdLogger creates a StdLogger.
+func NewStdLogger() *StdLogger { return &StdLogger{} }
+
+func (l *StdLogger) Info(ctx context.Context, msg string, kv ...any) {
+	log.Println(format(msg, kv...))
+}
+
+func (l *StdLogger) Error(ctx context.Context, msg string, kv ...any) {
+	log.Println(format(msg, kv...))
+}
+
+func format(msg string, kv ...any) string {
+	if len(kv) == 0 {
+		return msg
+	}
+	pairs := make([]string, 0, len(kv)/2)
+	for i := 0; i < len(kv); i += 2 {
+		key := fmt.Sprint(kv[i])
+		val := ""
+		if i+1 < len(kv) {
+			val = fmt.Sprint(kv[i+1])
+		}
+		pairs = append(pairs, fmt.Sprintf("%s=%s", key, val))
+	}
+	return msg + " " + strings.Join(pairs, " ")
+}


### PR DESCRIPTION
## Summary
- add minimal logger interface with context
- wire logger through DI and background tasks
- log alert ticker events with structured fields
- start telegram polling with logger
- update tests for new logging setup

## Testing
- `go fmt ./...`
- `goimports -w .`
- `staticcheck ./...` *(fails: requires newer Go version)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ae494ad3883298f7be37e1f1eef09