### PR TITLE
feat(di): add app initializer

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,47 +1,18 @@
 package main
 
 import (
-	"context"
 	"log"
-	"os"
-	"time"
 
-	"github.com/gofiber/fiber/v2"
 	"github.com/joho/godotenv"
-	"github.com/nomenarkt/vitaltrack/backend/internal/background"
+
+	_ "github.com/nomenarkt/vitaltrack/backend/internal/background"
 	"github.com/nomenarkt/vitaltrack/backend/internal/di"
-	"github.com/nomenarkt/vitaltrack/backend/internal/server"
 )
 
 func main() {
 	_ = godotenv.Load()
-	app := fiber.New()
 
-	// ⛓️ Resolve dependencies via central initializer
-	deps := di.Init()
+	app := di.NewApp()
 
-	// ✅ Setup all HTTP routes with DI
-	server.SetupRoutes(app, deps.StockChecker, deps.ForecastSvc, deps.MedicineSvc, deps.Airtable, deps.Telegram)
-
-	// 🔄 Start background stock check if enabled
-	tickerInterval := 24 * time.Hour
-	if val := os.Getenv("ALERT_TICKER_INTERVAL"); val != "" {
-		d, err := time.ParseDuration(val)
-		if err != nil {
-			log.Printf("invalid ALERT_TICKER_INTERVAL %q: %v", val, err)
-		} else {
-			tickerInterval = d
-		}
-	}
-	if os.Getenv("ENABLE_ALERT_TICKER") == "true" {
-		background.StartStockAlertTicker(context.Background(), deps, tickerInterval, time.Now)
-	}
-
-	// 🧭 Start Telegram bot polling for `/stock` commands if enabled
-	if os.Getenv("ENABLE_TELEGRAM_POLLING") == "true" {
-		di.StartTelegramPolling(context.Background(), deps)
-	}
-
-	// 🚀 Run server
 	log.Fatal(app.Listen(":8787"))
 }

--- a/backend/internal/background/ticker.go
+++ b/backend/internal/background/ticker.go
@@ -79,3 +79,7 @@ func StartStockAlertTicker(ctx context.Context, deps di.Dependencies, interval t
 	}()
 	return func() { close(stopCh) }
 }
+
+func init() {
+	di.StartTickerFunc = StartStockAlertTicker
+}

--- a/backend/internal/di/app.go
+++ b/backend/internal/di/app.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"os"
 	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/nomenarkt/vitaltrack/backend/internal/server"
 )
 
 var (
@@ -30,4 +33,23 @@ func StartFromEnv(ctx context.Context, deps Dependencies) {
 	if os.Getenv("ENABLE_TELEGRAM_POLLING") == "true" && PollingFunc != nil {
 		PollingFunc(ctx, deps)
 	}
+}
+
+// NewApp initializes the Fiber application with all routes and optional
+// background processes. It resolves dependencies via Init() and returns the
+// configured *fiber.App instance.
+func NewApp() *fiber.App {
+	app := fiber.New()
+
+	deps := Init()
+
+	server.SetupRoutes(app, deps.StockChecker, deps.ForecastSvc, deps.MedicineSvc, deps.Airtable, deps.Telegram)
+
+	if PollingFunc == nil {
+		PollingFunc = StartTelegramPolling
+	}
+
+	StartFromEnv(context.Background(), deps)
+
+	return app
 }


### PR DESCRIPTION
## Summary
- create NewApp initializer in di package
- simplify server main
- hook up ticker via background init
- test new app bootstrap logic

## Testing
- `staticcheck ./...` *(fails: requires newer Go version)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ae81be4ec8329973e16b5a071d79b