### PR TITLE
Fix golangci config

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -7,9 +7,7 @@ run:
     - migrations
 
 output:
-  print-issued-lines: true
-  formats:
-    - format: colored-line-number
+  format: colored-line-number
 
 issues:
   exclude-use-default: false
@@ -71,8 +69,11 @@ linters-settings:
         message: "Use structured logger instead (zap, slog, etc.)"
       - name: "log.Println"
         message: "Avoid standard log, use centralized logger"
+      - name: "log.Fatal"
+        message: "Do not call log.Fatal directly in app — use graceful shutdown"
     path-exclude:
       - "**/*_test.go"
+      - "**/testdata/**"
     allow:
       # ✅ COMMON GO IDENTIFIERS
       - "err"


### PR DESCRIPTION
## Summary
- simplify `output` section
- forbid calling `log.Fatal` directly
- exclude testdata directory from forbidigo checks

## Testing
- `make lint` *(fails: unsupported config)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684b068ac5808329bb195dd25c344bdb