### PR TITLE
fix(ci): standardize go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 🛠 Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.4'
+          go-version: '1.24'
 
       - name: 🔍 Cache Go modules
         uses: actions/cache@v3

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/nomenarkt/vitaltrack/backend
 
-go 1.24.1
+go 1.24
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.8


### PR DESCRIPTION
## Summary
- drop patch version from Go directive
- align CI Go version with go.mod

## Testing
- `go mod tidy`
- `make test`
- `go build ./...`
- `make lint` *(fails: unsupported config)*

------
https://chatgpt.com/codex/tasks/task_e_684b93eb8d008329a6050e25c9252a7b