### PR TITLE
chore: specify golangci-lint config version

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,3 +1,4 @@
+version: 2
 run:
   timeout: 3m
   tests: true


### PR DESCRIPTION
## Summary
- add `version: 2` to backend/.golangci.yml

## Testing
- `go fmt ./...`
- `goimports -w .`
- `staticcheck ./...`
- `golangci-lint run ./...` *(fails: typecheck is not a linter)*

------
https://chatgpt.com/codex/tasks/task_e_684bb10533fc83298f52ca37896e2590