### PR TITLE
fix: update golangci config

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,3 +1,4 @@
+version: 2
 run:
   timeout: 3m
   tests: true
@@ -36,13 +37,10 @@ linters:
     - govet
     - errcheck
     - staticcheck
-    - gofmt
-    - goimports
     - revive
     - gocritic
     - ineffassign
     - unused
-    - typecheck
     - depguard
     - nakedret
     - bodyclose


### PR DESCRIPTION
## Summary
- remove unsupported linters from golangci config

## Testing
- `go fmt ./...`
- `goimports -w .`
- `staticcheck ./...` *(fails: module requires Go 1.24)*
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_684bb10533fc83298f52ca37896e2590