### PR TITLE
fix: replace log.Fatal with panic

### DIFF
--- a/backend/internal/infra/airtable/client.go
+++ b/backend/internal/infra/airtable/client.go
@@ -30,7 +30,7 @@ func NewClient() *Client {
 		os.Getenv("AIRTABLE_MEDICINES_TABLE") == "" ||
 		os.Getenv("AIRTABLE_ENTRIES_TABLE") == "" ||
 		os.Getenv("AIRTABLE_TOKEN") == "" {
-		log.Fatal("missing Airtable configuration: ensure AIRTABLE_BASE_ID, AIRTABLE_MEDICINES_TABLE, AIRTABLE_ENTRIES_TABLE and AIRTABLE_TOKEN are set")
+		panic("missing Airtable configuration: ensure AIRTABLE_BASE_ID, AIRTABLE_MEDICINES_TABLE, AIRTABLE_ENTRIES_TABLE and AIRTABLE_TOKEN are set")
 	}
 
 	baseURL := os.Getenv("AIRTABLE_API_BASE_URL")

--- a/backend/internal/infra/telegram/client.go
+++ b/backend/internal/infra/telegram/client.go
@@ -40,7 +40,7 @@ func NewClient() *Client {
 		baseURL = "https://api.telegram.org"
 	}
 	if token == "" || chatID == "" {
-		log.Fatal("missing Telegram configuration: TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must be set")
+		panic("missing Telegram configuration: TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must be set")
 	}
 
 	return &Client{


### PR DESCRIPTION
## Summary
- avoid log.Fatal in Airtable client
- avoid log.Fatal in Telegram client
- run go vet and golangci-lint

## Testing
- `go vet ./...`
- `golangci-lint run ./...` *(fails: depguard, errcheck, revive issues)*

------
https://chatgpt.com/codex/tasks/task_e_684bb59a90c083298384899355319fd9