### PR TITLE
fix: replace log.Println with log.Printf

### DIFF
--- a/backend/internal/infra/airtable/client.go
+++ b/backend/internal/infra/airtable/client.go
@@ -66,7 +66,7 @@ func (c *Client) FetchMedicines() ([]domain.Medicine, error) {
 	}
 	defer func() {
 		if cerr := res.Body.Close(); cerr != nil {
-			log.Println("airtable response close error:", cerr)
+			log.Printf("airtable response close error: %v", cerr)
 		}
 	}()
 
@@ -109,7 +109,7 @@ func (c *Client) FetchStockEntries() ([]domain.StockEntry, error) {
 	}
 	defer func() {
 		if cerr := res.Body.Close(); cerr != nil {
-			log.Println("airtable response close error:", cerr)
+			log.Printf("airtable response close error: %v", cerr)
 		}
 	}()
 
@@ -164,7 +164,7 @@ func (c *Client) CreateStockEntry(entry domain.StockEntry) error {
 	}
 	defer func() {
 		if cerr := res.Body.Close(); cerr != nil {
-			log.Println("airtable response close error:", cerr)
+			log.Printf("airtable response close error: %v", cerr)
 		}
 	}()
 
@@ -204,7 +204,7 @@ func (c *Client) UpdateForecastDate(medicineID string, forecastDate, updatedAt t
 	}
 	defer func() {
 		if cerr := res.Body.Close(); cerr != nil {
-			log.Println("airtable response close error:", cerr)
+			log.Printf("airtable response close error: %v", cerr)
 		}
 	}()
 
@@ -243,7 +243,7 @@ func (c *Client) UpdateMedicineLastAlertedDate(medicineID string, date time.Time
 	}
 	defer func() {
 		if cerr := res.Body.Close(); cerr != nil {
-			log.Println("airtable response close error:", cerr)
+			log.Printf("airtable response close error: %v", cerr)
 		}
 	}()
 
@@ -285,7 +285,7 @@ func (c *Client) FetchFinancialEntries(year int, month time.Month) ([]domain.Fin
 	defer res.Body.Close()
 
 	body, _ := io.ReadAll(res.Body)
-	log.Println("🧾 Raw Airtable response:", string(body))
+	log.Printf("🧾 Raw Airtable response: %s", string(body))
 
 	var errCheck map[string]interface{}
 	if json.Unmarshal(body, &errCheck) == nil {

--- a/backend/internal/infra/telegram/client.go
+++ b/backend/internal/infra/telegram/client.go
@@ -74,7 +74,7 @@ func (c *Client) SendTelegramMessage(msg string) error {
 	}
 	defer func() {
 		if cerr := res.Body.Close(); cerr != nil {
-			log.Println("telegram response close error:", cerr)
+			log.Printf("telegram response close error: %v", cerr)
 		}
 	}()
 
@@ -109,24 +109,24 @@ func (c *Client) PollForCommands(
 ) {
 	var lastUpdateID int
 
-	log.Println("📨 Telegram polling started...")
+	log.Printf("%s", "📨 Telegram polling started...")
 	for {
 		time.Sleep(2 * time.Second)
 
 		apiURL := fmt.Sprintf("%s/bot%s/getUpdates?timeout=10&offset=%d", c.baseURL, c.Token, lastUpdateID+1)
 		resp, err := http.Get(apiURL)
 		if err != nil {
-			log.Println("Telegram polling error:", err)
+			log.Printf("Telegram polling error: %v", err)
 			continue
 		}
 		body, _ := io.ReadAll(resp.Body)
 		if err := resp.Body.Close(); err != nil {
-			log.Println("Telegram response close error:", err)
+			log.Printf("Telegram response close error: %v", err)
 		}
 
 		var updates GetUpdatesResponse
 		if err := json.Unmarshal(body, &updates); err != nil {
-			log.Println("Failed to decode Telegram updates:", err)
+			log.Printf("Failed to decode Telegram updates: %v", err)
 			continue
 		}
 		if !updates.OK {
@@ -138,10 +138,10 @@ func (c *Client) PollForCommands(
 			lastUpdateID = update.UpdateID
 			switch {
 			case update.Message.Text == "/stock":
-				log.Println("🟡 /stock command triggered")
+				log.Printf("%s", "🟡 /stock command triggered")
 				go c.handleStockCommand(update.Message.Chat.ID, fetchData)
 			case strings.HasPrefix(update.Message.Text, "/finance"):
-				log.Println("🟡 /finance command triggered")
+				log.Printf("%s", "🟡 /finance command triggered")
 				year, month := time.Now().Year(), time.Now().Month()
 				parts := strings.Fields(update.Message.Text)
 				if len(parts) > 1 {
@@ -159,7 +159,7 @@ func (c *Client) handleStockCommand(chatID int64, fetchData func() ([]domain.Med
 	meds, entries, err := fetchData()
 	if err != nil {
 		if err := c.sendTo(chatID, "\u26a0\ufe0f Failed to fetch stock data."); err != nil {
-			log.Println("failed to send /stock response:", err)
+			log.Printf("failed to send /stock response: %v", err)
 		}
 		return
 	}
@@ -167,7 +167,7 @@ func (c *Client) handleStockCommand(chatID int64, fetchData func() ([]domain.Med
 	log.Printf("📦 meds: %d, entries: %d", len(meds), len(entries))
 	if len(meds) == 0 {
 		if err := c.sendTo(chatID, "\u26a0\ufe0f No medicine or stock data found."); err != nil {
-			log.Println("failed to send /stock response:", err)
+			log.Printf("failed to send /stock response: %v", err)
 		}
 		return
 	}
@@ -190,7 +190,7 @@ func (c *Client) handleStockCommand(chatID int64, fetchData func() ([]domain.Med
 
 	if len(rows) == 0 {
 		if err := c.sendTo(chatID, "\u2705 All medicines are well stocked."); err != nil {
-			log.Println("failed to send /stock response:", err)
+			log.Printf("failed to send /stock response: %v", err)
 		}
 		return
 	}
@@ -206,9 +206,9 @@ func (c *Client) handleStockCommand(chatID int64, fetchData func() ([]domain.Med
 
 	msg := "*Out-of-Stock Forecast*\n\n```text\n" + strings.Join(lines, "\n") + "\n```"
 	if err := c.sendTo(chatID, msg); err != nil {
-		log.Println("failed to send /stock response:", err)
+		log.Printf("failed to send /stock response: %v", err)
 	} else {
-		log.Println("sent /stock forecast")
+		log.Printf("%s", "sent /stock forecast")
 	}
 }
 
@@ -217,7 +217,7 @@ func (c *Client) handleFinanceCommand(chatID int64, fn func(year, month int) (do
 	report, err := fn(year, int(month))
 	if err != nil {
 		if err := c.sendTo(chatID, "\u26a0\ufe0f Failed to fetch financial data."); err != nil {
-			log.Println("failed to send /finance response:", err)
+			log.Printf("failed to send /finance response: %v", err)
 		}
 		return
 	}
@@ -243,7 +243,7 @@ func (c *Client) handleFinanceCommand(chatID int64, fn func(year, month int) (do
 		report.Year, report.Month, strings.Join(sections, "\n\n"), strings.Join(summary, "\n"))
 
 	if err := c.sendTo(chatID, msg); err != nil {
-		log.Println("failed to send /finance response:", err)
+		log.Printf("failed to send /finance response: %v", err)
 	}
 }
 
@@ -271,7 +271,7 @@ func (c *Client) sendTo(chatID int64, msg string) error {
 	}
 	defer func() {
 		if cerr := res.Body.Close(); cerr != nil {
-			log.Println("telegram response close error:", cerr)
+			log.Printf("telegram response close error: %v", cerr)
 		}
 	}()
 

--- a/backend/internal/logger/logger.go
+++ b/backend/internal/logger/logger.go
@@ -22,12 +22,12 @@ func NewStdLogger() *StdLogger { return &StdLogger{} }
 
 // Info logs an informational message with optional key-value pairs.
 func (l *StdLogger) Info(_ context.Context, msg string, kv ...any) {
-	log.Println(format(msg, kv...))
+	log.Printf("%s", format(msg, kv...))
 }
 
 // Error logs an error message with optional key-value pairs.
 func (l *StdLogger) Error(_ context.Context, msg string, kv ...any) {
-	log.Println(format(msg, kv...))
+	log.Printf("%s", format(msg, kv...))
 }
 
 func format(msg string, kv ...any) string {


### PR DESCRIPTION
## Summary
- use `log.Printf` in logger
- update Telegram and Airtable clients to avoid `log.Println`

## Testing
- `make test`
- `golangci-lint run --timeout=2m | grep -i forbid`

------
https://chatgpt.com/codex/tasks/task_e_684bb7df926883299cca9497c4c0d2db