### PR TITLE
fix: enforce error checks in tests

### DIFF
--- a/backend/internal/background/ticker_test.go
+++ b/backend/internal/background/ticker_test.go
@@ -49,7 +49,9 @@ func (h *httpTelegram) SendTelegramMessage(msg string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		return err
+	}
 	*h.posted = append(*h.posted, msg)
 	return nil
 }
@@ -152,7 +154,9 @@ func TestStartStockAlertTicker_HTTP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			posted := []string{}
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				_, _ = io.ReadAll(r.Body)
+				if _, err := io.ReadAll(r.Body); err != nil {
+					t.Errorf("read body: %v", err)
+				}
 				posted = append(posted, r.URL.Path)
 				w.WriteHeader(http.StatusOK)
 			}))

--- a/backend/internal/di/app_test.go
+++ b/backend/internal/di/app_test.go
@@ -49,17 +49,29 @@ func TestStartFromEnv(t *testing.T) {
 					t.Fatal(err)
 				}
 			} else {
-				os.Unsetenv("ENABLE_ALERT_TICKER")
+				if err := os.Unsetenv("ENABLE_ALERT_TICKER"); err != nil {
+					t.Fatal(err)
+				}
 			}
 			if tt.pollingEnabled {
 				if err := os.Setenv("ENABLE_TELEGRAM_POLLING", "true"); err != nil {
 					t.Fatal(err)
 				}
 			} else {
-				os.Unsetenv("ENABLE_TELEGRAM_POLLING")
+				if err := os.Unsetenv("ENABLE_TELEGRAM_POLLING"); err != nil {
+					t.Fatal(err)
+				}
 			}
-			defer os.Unsetenv("ENABLE_ALERT_TICKER")
-			defer os.Unsetenv("ENABLE_TELEGRAM_POLLING")
+			defer func() {
+				if err := os.Unsetenv("ENABLE_ALERT_TICKER"); err != nil {
+					t.Fatal(err)
+				}
+			}()
+			defer func() {
+				if err := os.Unsetenv("ENABLE_TELEGRAM_POLLING"); err != nil {
+					t.Fatal(err)
+				}
+			}()
 
 			tickerCalled := false
 			pollingCalled := false
@@ -108,12 +120,24 @@ func TestNewApp(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		os.Unsetenv("AIRTABLE_BASE_ID")
-		os.Unsetenv("AIRTABLE_MEDICINES_TABLE")
-		os.Unsetenv("AIRTABLE_ENTRIES_TABLE")
-		os.Unsetenv("AIRTABLE_TOKEN")
-		os.Unsetenv("TELEGRAM_BOT_TOKEN")
-		os.Unsetenv("TELEGRAM_CHAT_ID")
+		if err := os.Unsetenv("AIRTABLE_BASE_ID"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Unsetenv("AIRTABLE_MEDICINES_TABLE"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Unsetenv("AIRTABLE_ENTRIES_TABLE"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Unsetenv("AIRTABLE_TOKEN"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Unsetenv("TELEGRAM_BOT_TOKEN"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Unsetenv("TELEGRAM_CHAT_ID"); err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	tests := []struct {
@@ -136,17 +160,29 @@ func TestNewApp(t *testing.T) {
 					t.Fatal(err)
 				}
 			} else {
-				os.Unsetenv("ENABLE_ALERT_TICKER")
+				if err := os.Unsetenv("ENABLE_ALERT_TICKER"); err != nil {
+					t.Fatal(err)
+				}
 			}
 			if tt.pollingEnabled {
 				if err := os.Setenv("ENABLE_TELEGRAM_POLLING", "true"); err != nil {
 					t.Fatal(err)
 				}
 			} else {
-				os.Unsetenv("ENABLE_TELEGRAM_POLLING")
+				if err := os.Unsetenv("ENABLE_TELEGRAM_POLLING"); err != nil {
+					t.Fatal(err)
+				}
 			}
-			defer os.Unsetenv("ENABLE_ALERT_TICKER")
-			defer os.Unsetenv("ENABLE_TELEGRAM_POLLING")
+			defer func() {
+				if err := os.Unsetenv("ENABLE_ALERT_TICKER"); err != nil {
+					t.Fatal(err)
+				}
+			}()
+			defer func() {
+				if err := os.Unsetenv("ENABLE_TELEGRAM_POLLING"); err != nil {
+					t.Fatal(err)
+				}
+			}()
 
 			tickerCalled := false
 			pollingCalled := false

--- a/backend/internal/di/telegram_polling_test.go
+++ b/backend/internal/di/telegram_polling_test.go
@@ -42,8 +42,12 @@ type mockTelegram struct{ done chan struct{} }
 
 func (m *mockTelegram) SendTelegramMessage(string) error { return nil }
 func (m *mockTelegram) PollForCommands(fetch func() ([]domain.Medicine, []domain.StockEntry, error), report func(int, int) (domain.MonthlyFinancialReport, error)) {
-	fetch()
-	report(2024, 6)
+	if _, _, err := fetch(); err != nil {
+		panic(err)
+	}
+	if _, err := report(2024, 6); err != nil {
+		panic(err)
+	}
 	close(m.done)
 }
 

--- a/backend/internal/infra/airtable/client_test.go
+++ b/backend/internal/infra/airtable/client_test.go
@@ -24,9 +24,15 @@ func TestUpdateMedicineLastAlertedDate(t *testing.T) {
 	var body []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path = r.URL.Path
-		body, _ = io.ReadAll(r.Body)
+		var err error
+		body, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"id":"%s","fields":{"last_alerted_date":"%s"}}`, recID, date.Format("2006-01-02"))
+		if _, err := fmt.Fprintf(w, `{"id":"%s","fields":{"last_alerted_date":"%s"}}`, recID, date.Format("2006-01-02")); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -70,7 +76,9 @@ func TestUpdateMedicineLastAlertedDate(t *testing.T) {
 func TestUpdateMedicineLastAlertedDate_ignoresMismatch(t *testing.T) {
 	date := time.Date(2025, 6, 10, 0, 0, 0, 0, time.UTC)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, `{"id":"rec","fields":{"last_alerted_date":"2024-01-01"}}`)
+		if _, err := fmt.Fprint(w, `{"id":"rec","fields":{"last_alerted_date":"2024-01-01"}}`); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -104,7 +112,9 @@ func TestUpdateMedicineLastAlertedDate_errorStatus(t *testing.T) {
 	date := time.Date(2025, 6, 10, 0, 0, 0, 0, time.UTC)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprint(w, "bad")
+		if _, err := fmt.Fprint(w, "bad"); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -145,8 +155,14 @@ func TestUpdateForecastDate(t *testing.T) {
 	var body []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path = r.URL.Path
-		body, _ = io.ReadAll(r.Body)
-		fmt.Fprint(w, `{}`)
+		var err error
+		body, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if _, err := fmt.Fprint(w, `{}`); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -189,7 +205,9 @@ func TestUpdateForecastDate(t *testing.T) {
 
 func TestFetchMedicines_AssignsID(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, `{"records":[{"id":"recA","fields":{"name":"MedA"}}]}`)
+		if _, err := fmt.Fprint(w, `{"records":[{"id":"recA","fields":{"name":"MedA"}}]}`); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -217,7 +235,9 @@ func TestFetchFinancialEntries(t *testing.T) {
 	var query string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query = r.URL.RawQuery
-		fmt.Fprint(w, `{"records":[{"id":"rec1","fields":{"Date":"2025-06-05","NeedLabel":"Med","NeedAmount":5,"AmountContributed":10,"MonthTag":"2025-06","Contributor":"Alice"}},{"id":"rec2","fields":{"Date":"2025-07-05","NeedLabel":"Med","NeedAmount":5,"AmountContributed":10,"MonthTag":"2025-07","Contributor":"Bob"}}]}`)
+		if _, err := fmt.Fprint(w, `{"records":[{"id":"rec1","fields":{"Date":"2025-06-05","NeedLabel":"Med","NeedAmount":5,"AmountContributed":10,"MonthTag":"2025-06","Contributor":"Alice"}},{"id":"rec2","fields":{"Date":"2025-07-05","NeedLabel":"Med","NeedAmount":5,"AmountContributed":10,"MonthTag":"2025-07","Contributor":"Bob"}}]}`); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -248,7 +268,9 @@ func TestFetchFinancialEntries(t *testing.T) {
 
 func TestFetchFinancialEntries_fields(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, `{"records":[{"id":"rec1","fields":{"Date":"2025-08-10","NeedLabel":"Food","NeedAmount":15,"AmountContributed":5,"MonthTag":"2025-08","Contributor":"Bob"}}]}`)
+		if _, err := fmt.Fprint(w, `{"records":[{"id":"rec1","fields":{"Date":"2025-08-10","NeedLabel":"Food","NeedAmount":15,"AmountContributed":5,"MonthTag":"2025-08","Contributor":"Bob"}}]}`); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -281,7 +303,9 @@ func TestFetchFinancialEntries_fields(t *testing.T) {
 
 func TestFetchFinancialEntries_zeroContribution(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, `{"records":[{"id":"rec1","fields":{"Date":"2025-09-20","NeedLabel":"Med","NeedAmount":100,"AmountContributed":0,"MonthTag":"2025-09","Contributor":"Alice"}}]}`)
+		if _, err := fmt.Fprint(w, `{"records":[{"id":"rec1","fields":{"Date":"2025-09-20","NeedLabel":"Med","NeedAmount":100,"AmountContributed":0,"MonthTag":"2025-09","Contributor":"Alice"}}]}`); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary
- add missing error checks for body close and Unsetenv calls
- assert errors from Fprint/Fprintf/ReadAll
- check mocked Telegram poll errors

## Testing
- `go test ./...`
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_684bbc39c7d483298937a8d196f11ceb