### PR TITLE
fix(server): log telegram send errors

### DIFF
--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -4,6 +4,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -67,7 +68,9 @@ func SetupRoutes(
 				info.CurrentStock,
 				info.OutOfStockDate.Format("Jan 2, 2006"),
 			)
-			_ = telegramClient.SendTelegramMessage(alert)
+			if err := telegramClient.SendTelegramMessage(alert); err != nil {
+				log.Printf("telegram send error: %v", err)
+			}
 		}
 
 		return c.JSON(fiber.Map{


### PR DESCRIPTION
## Summary
- add log import in routes
- handle telegram send errors and log them using `log.Printf`

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: depguard issues & unused params)*
- `staticcheck ./...` *(fails: module requires newer Go version)*

------
https://chatgpt.com/codex/tasks/task_e_684bbe799d848329bdb77fb2861a8ea0