### PR TITLE
feat: alert new refills via background ticker

### DIFF
--- a/backend/internal/background/ticker.go
+++ b/backend/internal/background/ticker.go
@@ -72,6 +72,12 @@ func StartStockAlertTicker(ctx context.Context, deps di.Dependencies, interval t
 				}
 			}
 
+			if deps.StockChecker != nil {
+				if err := deps.StockChecker.CheckAndAlertNewRefills(); err != nil {
+					deps.Logger.Error(ctx, "refill check failed", "error", err)
+				}
+			}
+
 			deps.Logger.Info(ctx, "alert ticker completed")
 
 			select {

--- a/backend/internal/usecase/refill.go
+++ b/backend/internal/usecase/refill.go
@@ -1,0 +1,73 @@
+package usecase
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/nomenarkt/vitaltrack/backend/internal/domain"
+	"github.com/nomenarkt/vitaltrack/backend/internal/util"
+)
+
+// CheckAndAlertNewRefills notifies when new stock entries are recorded for today.
+// It fetches medicines and stock entries, filters today's refills and sends a
+// Telegram alert per entry.
+func (s *StockChecker) CheckAndAlertNewRefills() error {
+	now := time.Now().UTC()
+	log.Printf("📡 Starting CheckAndAlertNewRefills...")
+
+	meds, err := s.Airtable.FetchMedicines()
+	if err != nil {
+		return fmt.Errorf("fetch medicines failed: %w", err)
+	}
+	entries, err := s.Airtable.FetchStockEntries()
+	if err != nil {
+		return fmt.Errorf("fetch stock entries failed: %w", err)
+	}
+
+	medMap := make(map[string]domain.Medicine)
+	for _, m := range meds {
+		medMap[m.ID] = m
+	}
+
+	today := now.Format("2006-01-02")
+
+	for _, e := range entries {
+		if e.MedicineID == "" || e.Quantity <= 0 || e.Date.IsZero() {
+			continue
+		}
+		if e.Date.UTC().Format("2006-01-02") != today {
+			continue
+		}
+
+		med, ok := medMap[e.MedicineID]
+		if !ok {
+			continue
+		}
+		if med.LastAlertedDate != nil && med.LastAlertedDate.UTC().Format("2006-01-02") == today {
+			continue
+		}
+
+		qty := e.Quantity
+		if e.Unit == "box" {
+			qty = qty * med.UnitPerBox
+		}
+
+		msg := fmt.Sprintf(
+			"✅ Refill received: %s\n• Quantity: %.0f %s\n• Converted: %.0f pills\n• Date: %s",
+			util.EscapeMarkdown(med.Name),
+			e.Quantity,
+			util.EscapeMarkdown(e.Unit),
+			qty,
+			e.Date.Format("2006-01-02"),
+		)
+
+		if err := s.Telegram.SendTelegramMessage(msg); err != nil {
+			log.Printf("❌ Telegram send failed: %v", err)
+		} else {
+			log.Printf("✅ Refill alert sent: %s", med.Name)
+		}
+	}
+
+	return nil
+}

--- a/backend/internal/usecase/refill_test.go
+++ b/backend/internal/usecase/refill_test.go
@@ -1,0 +1,97 @@
+package usecase_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/vitaltrack/backend/internal/domain"
+	"github.com/nomenarkt/vitaltrack/backend/internal/usecase"
+)
+
+// Mocks for Airtable and Telegram
+
+type mockAirtableRefill struct {
+	meds    []domain.Medicine
+	entries []domain.StockEntry
+}
+
+func (m *mockAirtableRefill) FetchMedicines() ([]domain.Medicine, error)      { return m.meds, nil }
+func (m *mockAirtableRefill) FetchStockEntries() ([]domain.StockEntry, error) { return m.entries, nil }
+func (m *mockAirtableRefill) FetchFinancialEntries(int, time.Month) ([]domain.FinancialEntry, error) {
+	return nil, nil
+}
+func (m *mockAirtableRefill) UpdateMedicineLastAlertedDate(string, time.Time) error { return nil }
+func (m *mockAirtableRefill) CreateStockEntry(domain.StockEntry) error              { return nil }
+func (m *mockAirtableRefill) UpdateForecastDate(string, time.Time, time.Time) error { return nil }
+
+type mockTelegramRefill struct{ msgs []string }
+
+func (m *mockTelegramRefill) SendTelegramMessage(msg string) error {
+	m.msgs = append(m.msgs, msg)
+	return nil
+}
+func (m *mockTelegramRefill) PollForCommands(func() ([]domain.Medicine, []domain.StockEntry, error), func(int, int) (domain.MonthlyFinancialReport, error)) {
+}
+
+func TestCheckAndAlertNewRefills(t *testing.T) {
+	now := time.Now().UTC().Truncate(24 * time.Hour)
+
+	med := domain.Medicine{ID: "m1", Name: "Med1", UnitPerBox: 28}
+	twoEntries := []domain.StockEntry{
+		{MedicineID: "m1", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)},
+		{MedicineID: "m1", Quantity: 10, Unit: "pill", Date: domain.NewFlexibleDate(now)},
+	}
+
+	tests := []struct {
+		name        string
+		meds        []domain.Medicine
+		entries     []domain.StockEntry
+		expectCount int
+	}{
+		{
+			name:        "single_entry",
+			meds:        []domain.Medicine{med},
+			entries:     []domain.StockEntry{twoEntries[0]},
+			expectCount: 1,
+		},
+		{
+			name:        "two_entries_same_medicine",
+			meds:        []domain.Medicine{med},
+			entries:     twoEntries,
+			expectCount: 2,
+		},
+		{
+			name:        "zero_quantity",
+			meds:        []domain.Medicine{med},
+			entries:     []domain.StockEntry{{MedicineID: "m1", Quantity: 0, Unit: "box", Date: domain.NewFlexibleDate(now)}},
+			expectCount: 0,
+		},
+		{
+			name:        "missing_medicine_id",
+			meds:        []domain.Medicine{med},
+			entries:     []domain.StockEntry{{MedicineID: "", Quantity: 2, Unit: "box", Date: domain.NewFlexibleDate(now)}},
+			expectCount: 0,
+		},
+		{
+			name:        "already_alerted_today",
+			meds:        []domain.Medicine{{ID: "m1", Name: "Med1", UnitPerBox: 28, LastAlertedDate: &domain.FlexibleDate{Time: now}}},
+			entries:     []domain.StockEntry{{MedicineID: "m1", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)}},
+			expectCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			at := &mockAirtableRefill{meds: tt.meds, entries: tt.entries}
+			tg := &mockTelegramRefill{}
+
+			checker := usecase.StockChecker{Airtable: at, Telegram: tg}
+			if err := checker.CheckAndAlertNewRefills(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(tg.msgs) != tt.expectCount {
+				t.Errorf("expected %d messages, got %d", tt.expectCount, len(tg.msgs))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- implement `CheckAndAlertNewRefills` usecase to send Telegram alerts for today's refill entries
- call the new usecase from the background ticker
- cover refill alert logic with unit tests

## Testing
- `go fmt ./...`
- `goimports -w .`
- `staticcheck ./...` *(fails: module requires Go 1.24 while Staticcheck built with Go 1.23)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d1037844083298251a284f1617507