### PR TITLE
feat: support multiple medicine IDs

### DIFF
--- a/backend/internal/domain/models.go
+++ b/backend/internal/domain/models.go
@@ -18,7 +18,7 @@ type Medicine struct {
 // StockEntry records a consumption or purchase event for a medicine.
 type StockEntry struct {
 	ID         string       `json:"id"`
-	MedicineID string       `json:"medicine_id"`
+	MedicineID []string     `json:"medicine_id"`
 	Quantity   float64      `json:"quantity"`
 	Unit       string       `json:"unit"` // "box" or "pill"
 	Date       FlexibleDate `json:"date"`

--- a/backend/internal/infra/airtable/client.go
+++ b/backend/internal/infra/airtable/client.go
@@ -159,7 +159,7 @@ func (c *Client) CreateStockEntry(entry domain.StockEntry) error {
 
 	payload := map[string]any{
 		"fields": map[string]any{
-			"medicine_id": []string{entry.MedicineID},
+			"medicine_id": entry.MedicineID,
 			"quantity":    entry.Quantity,
 			"unit":        entry.Unit,
 			"date":        entry.Date.Format("2006-01-02"),

--- a/backend/internal/infra/telegram/client.go
+++ b/backend/internal/infra/telegram/client.go
@@ -184,7 +184,7 @@ func (c *Client) handleStockCommand(chatID int64, fetchData func() ([]domain.Med
 	var validEntries []domain.StockEntry
 	skipped := 0
 	for _, e := range entries {
-		if e.Date.IsZero() || e.MedicineID == "" || e.Quantity <= 0 {
+		if e.Date.IsZero() || len(e.MedicineID) == 0 || e.Quantity <= 0 {
 			log.Printf("⚠️ skipping invalid stock entry: %+v", e)
 			skipped++
 			continue

--- a/backend/internal/infra/telegram/client_test.go
+++ b/backend/internal/infra/telegram/client_test.go
@@ -52,13 +52,13 @@ func TestHandleStockCommand(t *testing.T) {
 		{
 			name:    "all_good",
 			meds:    []domain.Medicine{{ID: "m2", Name: "Med2", StartDate: domain.NewFlexibleDate(now), InitialStock: 0, DailyDose: 1, UnitPerBox: 10}},
-			entries: []domain.StockEntry{{MedicineID: "m2", Quantity: 1.0, Unit: "box", Date: domain.NewFlexibleDate(now)}},
+			entries: []domain.StockEntry{{MedicineID: []string{"m2"}, Quantity: 1.0, Unit: "box", Date: domain.NewFlexibleDate(now)}},
 			expect:  "*Out-of-Stock Forecast*",
 		},
 		{
 			name:    "forecast",
 			meds:    []domain.Medicine{{ID: "m3", Name: "Med3", StartDate: domain.NewFlexibleDate(now), InitialStock: 10, DailyDose: 1, UnitPerBox: 10}},
-			entries: []domain.StockEntry{{MedicineID: "m3", Quantity: 1.0, Unit: "box", Date: domain.NewFlexibleDate(now)}},
+			entries: []domain.StockEntry{{MedicineID: []string{"m3"}, Quantity: 1.0, Unit: "box", Date: domain.NewFlexibleDate(now)}},
 			expect:  "*Out-of-Stock Forecast*",
 		},
 	}
@@ -125,7 +125,7 @@ func TestHandleStockCommand_withFloatEntries(t *testing.T) {
 
 	now := time.Now().AddDate(0, 0, -1)
 	meds := []domain.Medicine{{ID: "m5", Name: "FloatMed", StartDate: domain.NewFlexibleDate(now), InitialStock: 0, DailyDose: 1, UnitPerBox: 10}}
-	entries := []domain.StockEntry{{MedicineID: "m5", Quantity: 0.75, Unit: "box", Date: domain.NewFlexibleDate(now)}}
+	entries := []domain.StockEntry{{MedicineID: []string{"m5"}, Quantity: 0.75, Unit: "box", Date: domain.NewFlexibleDate(now)}}
 	fetch := func() ([]domain.Medicine, []domain.StockEntry, error) {
 		return meds, entries, nil
 	}
@@ -150,7 +150,7 @@ func TestHandleStockCommand_zeroDose(t *testing.T) {
 
 	now := time.Now().AddDate(0, 0, -1)
 	meds := []domain.Medicine{{ID: "m6", Name: "ZeroDose", StartDate: domain.NewFlexibleDate(now), InitialStock: 10, DailyDose: 0, UnitPerBox: 10}}
-	entries := []domain.StockEntry{{MedicineID: "m6", Quantity: 1.0, Unit: "box", Date: domain.NewFlexibleDate(now)}}
+	entries := []domain.StockEntry{{MedicineID: []string{"m6"}, Quantity: 1.0, Unit: "box", Date: domain.NewFlexibleDate(now)}}
 	fetch := func() ([]domain.Medicine, []domain.StockEntry, error) {
 		return meds, entries, nil
 	}
@@ -212,9 +212,9 @@ func TestHandleStockCommand_refillAppliedCumulatively(t *testing.T) {
 	now := time.Now().UTC().Truncate(24 * time.Hour)
 	start := now.AddDate(0, 0, -5)
 	entries := []domain.StockEntry{
-		{MedicineID: "mref", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(start.AddDate(0, 0, 1))},
-		{MedicineID: "mref", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(start.AddDate(0, 0, 2))},
-		{MedicineID: "mref", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(start.AddDate(0, 0, 3))},
+		{MedicineID: []string{"mref"}, Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(start.AddDate(0, 0, 1))},
+		{MedicineID: []string{"mref"}, Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(start.AddDate(0, 0, 2))},
+		{MedicineID: []string{"mref"}, Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(start.AddDate(0, 0, 3))},
 	}
 	meds := []domain.Medicine{{ID: "mref", Name: "Refill", StartDate: domain.NewFlexibleDate(start), InitialStock: 0, DailyDose: 1, UnitPerBox: 10}}
 	fetch := func() ([]domain.Medicine, []domain.StockEntry, error) { return meds, entries, nil }
@@ -339,9 +339,9 @@ func TestHandleStockCommand_invalidEntriesSkipped(t *testing.T) {
 	now := time.Now().AddDate(0, 0, -1)
 	meds := []domain.Medicine{{ID: "sk1", Name: "SkipMed", StartDate: domain.NewFlexibleDate(now), InitialStock: 0, DailyDose: 1, UnitPerBox: 10}}
 	entries := []domain.StockEntry{
-		{MedicineID: "", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)},
-		{MedicineID: "sk1", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)},
-		{MedicineID: "sk1", Quantity: -2, Unit: "pill", Date: domain.FlexibleDate{}},
+		{MedicineID: []string{""}, Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)},
+		{MedicineID: []string{"sk1"}, Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)},
+		{MedicineID: []string{"sk1"}, Quantity: -2, Unit: "pill", Date: domain.FlexibleDate{}},
 	}
 	fetch := func() ([]domain.Medicine, []domain.StockEntry, error) { return meds, entries, nil }
 

--- a/backend/internal/logic/stockcalc/stockcalc.go
+++ b/backend/internal/logic/stockcalc/stockcalc.go
@@ -27,7 +27,7 @@ func CurrentStockAt(m domain.Medicine, entries []domain.StockEntry, now time.Tim
 
 	// Apply refills that occurred up to now (inclusive)
 	for _, e := range entries {
-		if e.MedicineID != m.ID {
+		if len(e.MedicineID) == 0 || e.MedicineID[0] != m.ID {
 			continue
 		}
 		if e.Date.IsZero() {

--- a/backend/internal/logic/stockcalc/stockcalc_test.go
+++ b/backend/internal/logic/stockcalc/stockcalc_test.go
@@ -30,7 +30,7 @@ func TestCurrentStockAt_WithRefillOnToday(t *testing.T) {
 
 	entries := []domain.StockEntry{
 		{
-			MedicineID: "med123",
+			MedicineID: []string{"med123"},
 			Quantity:   1.0,
 			Unit:       "box",
 			Date:       domain.NewFlexibleDate(now),
@@ -61,10 +61,10 @@ func TestCurrentStockAt_WithMultipleEntryDates(t *testing.T) {
 	}
 
 	entries := []domain.StockEntry{
-		{MedicineID: "med1", Quantity: 1.0, Unit: "box", Date: domain.NewFlexibleDate(today)},                    // +10
-		{MedicineID: "med1", Quantity: 5.0, Unit: "pill", Date: domain.NewFlexibleDate(today)},                   // +5
-		{MedicineID: "med1", Quantity: 5.0, Unit: "pill", Date: domain.NewFlexibleDate(today.AddDate(0, 0, 1))},  // future: ignored
-		{MedicineID: "med1", Quantity: 5.0, Unit: "pill", Date: domain.NewFlexibleDate(today.AddDate(0, 0, -1))}, // past: included
+		{MedicineID: []string{"med1"}, Quantity: 1.0, Unit: "box", Date: domain.NewFlexibleDate(today)},                    // +10
+		{MedicineID: []string{"med1"}, Quantity: 5.0, Unit: "pill", Date: domain.NewFlexibleDate(today)},                   // +5
+		{MedicineID: []string{"med1"}, Quantity: 5.0, Unit: "pill", Date: domain.NewFlexibleDate(today.AddDate(0, 0, 1))},  // future: ignored
+		{MedicineID: []string{"med1"}, Quantity: 5.0, Unit: "pill", Date: domain.NewFlexibleDate(today.AddDate(0, 0, -1))}, // past: included
 	}
 
 	stock := stockcalc.CurrentStockAt(med, entries, today)
@@ -106,7 +106,7 @@ func TestCurrentStockAt_WithRFC3339StartDate(t *testing.T) {
 
 	entries := []domain.StockEntry{
 		{
-			MedicineID: "medRFC",
+			MedicineID: []string{"medRFC"},
 			Quantity:   1.0,
 			Unit:       "box",
 			Date:       domain.NewFlexibleDate(now),
@@ -137,7 +137,7 @@ func TestCurrentStockAt_EntryDateRFC3339Match(t *testing.T) {
 	rfcDate := time.Date(2025, 6, 4, 12, 0, 0, 0, time.UTC)
 
 	entries := []domain.StockEntry{
-		{MedicineID: "med2", Quantity: 1.0, Unit: "box", Date: domain.NewFlexibleDate(rfcDate)},
+		{MedicineID: []string{"med2"}, Quantity: 1.0, Unit: "box", Date: domain.NewFlexibleDate(rfcDate)},
 	}
 
 	got := stockcalc.CurrentStockAt(med, entries, now)

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -117,7 +117,7 @@ func SetupRoutes(
 			}
 
 			entry := domain.StockEntry{
-				MedicineID: id,
+				MedicineID: []string{id},
 				Quantity:   req.Quantity,
 				Unit:       req.Unit,
 				Date:       domain.FlexibleDate{Time: parsedDate},

--- a/backend/internal/usecase/alert.go
+++ b/backend/internal/usecase/alert.go
@@ -91,8 +91,11 @@ func (s *StockChecker) CheckAndAlertLowStock() error {
 	// 👇 Refill notification logic
 	refillsToday := map[string][]domain.StockEntry{}
 	for _, entry := range entries {
+		if len(entry.MedicineID) == 0 {
+			continue
+		}
 		if entry.Date.UTC().Format("2006-01-02") == now.Format("2006-01-02") {
-			refillsToday[entry.MedicineID] = append(refillsToday[entry.MedicineID], entry)
+			refillsToday[entry.MedicineID[0]] = append(refillsToday[entry.MedicineID[0]], entry)
 		}
 	}
 

--- a/backend/internal/usecase/alert_test.go
+++ b/backend/internal/usecase/alert_test.go
@@ -106,7 +106,7 @@ func TestCheckAndAlertLowStock_Table(t *testing.T) {
 			},
 			entries: []domain.StockEntry{
 				{
-					MedicineID: "medr",
+					MedicineID: []string{"medr"},
 					Quantity:   2,
 					Unit:       "box",
 					Date:       domain.NewFlexibleDate(now),

--- a/backend/internal/usecase/medicine_test.go
+++ b/backend/internal/usecase/medicine_test.go
@@ -47,7 +47,7 @@ func TestGetStockInfo(t *testing.T) {
 		},
 		{
 			name:      "withEntries",
-			repo:      mockRepo{meds: []domain.Medicine{med}, entries: []domain.StockEntry{{MedicineID: "m1", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)}}},
+			repo:      mockRepo{meds: []domain.Medicine{med}, entries: []domain.StockEntry{{MedicineID: []string{"m1"}, Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)}}},
 			wantStock: 17,
 			wantDate:  time.Date(2025, 6, 21, 0, 0, 0, 0, time.UTC),
 		},

--- a/backend/internal/usecase/refill.go
+++ b/backend/internal/usecase/refill.go
@@ -33,14 +33,14 @@ func (s *StockChecker) CheckAndAlertNewRefills() error {
 	today := now.Format("2006-01-02")
 
 	for _, e := range entries {
-		if e.MedicineID == "" || e.Quantity <= 0 || e.Date.IsZero() {
+		if len(e.MedicineID) == 0 || e.Quantity <= 0 || e.Date.IsZero() {
 			continue
 		}
 		if e.Date.UTC().Format("2006-01-02") != today {
 			continue
 		}
 
-		med, ok := medMap[e.MedicineID]
+		med, ok := medMap[e.MedicineID[0]]
 		if !ok {
 			continue
 		}

--- a/backend/internal/usecase/refill_test.go
+++ b/backend/internal/usecase/refill_test.go
@@ -38,8 +38,8 @@ func TestCheckAndAlertNewRefills(t *testing.T) {
 
 	med := domain.Medicine{ID: "m1", Name: "Med1", UnitPerBox: 28}
 	twoEntries := []domain.StockEntry{
-		{MedicineID: "m1", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)},
-		{MedicineID: "m1", Quantity: 10, Unit: "pill", Date: domain.NewFlexibleDate(now)},
+		{MedicineID: []string{"m1"}, Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)},
+		{MedicineID: []string{"m1"}, Quantity: 10, Unit: "pill", Date: domain.NewFlexibleDate(now)},
 	}
 
 	tests := []struct {
@@ -63,19 +63,19 @@ func TestCheckAndAlertNewRefills(t *testing.T) {
 		{
 			name:        "zero_quantity",
 			meds:        []domain.Medicine{med},
-			entries:     []domain.StockEntry{{MedicineID: "m1", Quantity: 0, Unit: "box", Date: domain.NewFlexibleDate(now)}},
+			entries:     []domain.StockEntry{{MedicineID: []string{"m1"}, Quantity: 0, Unit: "box", Date: domain.NewFlexibleDate(now)}},
 			expectCount: 0,
 		},
 		{
 			name:        "missing_medicine_id",
 			meds:        []domain.Medicine{med},
-			entries:     []domain.StockEntry{{MedicineID: "", Quantity: 2, Unit: "box", Date: domain.NewFlexibleDate(now)}},
+			entries:     []domain.StockEntry{{MedicineID: []string{""}, Quantity: 2, Unit: "box", Date: domain.NewFlexibleDate(now)}},
 			expectCount: 0,
 		},
 		{
 			name:        "already_alerted_today",
 			meds:        []domain.Medicine{{ID: "m1", Name: "Med1", UnitPerBox: 28, LastAlertedDate: &domain.FlexibleDate{Time: now}}},
-			entries:     []domain.StockEntry{{MedicineID: "m1", Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)}},
+			entries:     []domain.StockEntry{{MedicineID: []string{"m1"}, Quantity: 1, Unit: "box", Date: domain.NewFlexibleDate(now)}},
 			expectCount: 0,
 		},
 	}

--- a/mock/airtable/__files/stockentries.json
+++ b/mock/airtable/__files/stockentries.json
@@ -3,7 +3,7 @@
     {
       "id": "entry1",
       "fields": {
-        "medicine_id": "ok1",
+        "medicine_id": ["ok1"],
         "quantity": 2,
         "unit": "box",
         "date": "2025-06-04"


### PR DESCRIPTION
## Summary
- change MedicineID to a string slice
- adjust routes and logic to use new slice type
- skip invalid entries in Telegram and Refill logic
- update Airtable client payload
- fix tests and mock data

## Testing
- `go fmt ./...`
- `goimports -w ...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d20672c288329b8b713bd22f0f4e2