### PR TITLE
feat(server): start alert ticker

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2,13 +2,12 @@
 package main
 
 import (
-	"context"
 	"log"
 	"os"
 
 	"github.com/joho/godotenv"
 
-	_ "github.com/nomenarkt/vitaltrack/backend/internal/background"
+	"github.com/nomenarkt/vitaltrack/backend/internal/background"
 	"github.com/nomenarkt/vitaltrack/backend/internal/di"
 )
 
@@ -17,10 +16,9 @@ func main() {
 		log.Printf("godotenv load: %v", err)
 	}
 
-	ctx := context.Background()
+	di.StartTickerFunc = background.StartStockAlertTicker
 
-	app, deps := di.Build()
-	go di.StartTelegramPolling(ctx, deps)
+	app := di.NewApp()
 
 	if err := app.Listen(":8787"); err != nil {
 		log.Printf("❌ Server failed to start: %v", err)

--- a/backend/internal/background/ticker.go
+++ b/backend/internal/background/ticker.go
@@ -16,7 +16,7 @@ import (
 // interval and sends Telegram alerts when medicines are running low. The
 // returned function stops the ticker.
 func StartStockAlertTicker(ctx context.Context, deps di.Dependencies, interval time.Duration, nowFn func() time.Time) (stop func()) {
-	deps.Logger.Info(ctx, "alert ticker started", "interval", interval)
+	deps.Logger.Info(ctx, fmt.Sprintf("🟢 Ticker started with interval %s", interval))
 	stopCh := make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(interval)


### PR DESCRIPTION
## Summary
- run ticker when server starts
- log ticker status with emoji

## Testing
- `go test ./...`
- `staticcheck ./...` *(fails: module requires newer Go version)*

------
https://chatgpt.com/codex/tasks/task_e_684d8be6f1b083298bca1f33d57c08f2